### PR TITLE
remove deployment action for PR 🔧

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 name: "Build and Deploy"
 


### PR DESCRIPTION
Currently any PR will trigger deployment for github pages from any related branch/fork. This is not an expected behaviour